### PR TITLE
Malformed base href e.g. <base href=""> cause the content parser to u…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ PATH
       awesome_print
       haml
       json
-      namespaced_redis
       nokogiri
       redis
+      redis-namespace
       sinatra
       slop
 
@@ -24,9 +24,7 @@ GEM
       rest-client
       simplecov (>= 0.7)
       thor
-    daemons (1.1.9)
     diff-lcs (1.2.4)
-    eventmachine (1.0.3)
     haml (4.0.3)
       tilt
     json (1.8.0)
@@ -64,10 +62,6 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.4.6)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.18.1)
     tilt (1.4.1)
 
@@ -91,4 +85,6 @@ DEPENDENCIES
   rspec-core
   sinatra
   slop
-  thin
+
+BUNDLED WITH
+   1.10.3

--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -236,6 +236,7 @@ class Cobweb
         request_options={}
         request_options['Cookie']= options[:cookies] if options[:cookies]
         request_options['User-Agent']= options[:user_agent] if options.has_key?(:user_agent)
+        request_options['Accept-Encoding'] = 'identity' # This is used to accept
 
         request = Net::HTTP::Get.new uri.request_uri, request_options
         # authentication

--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -318,7 +318,7 @@ class Cobweb
           if @options[:store_image_attributes]
             Array(link_parser.full_link_data.select {|link| link["type"] == "image"}).each do |inbound_link|
               inbound_link["link"] = UriHelper.parse(inbound_link["link"])
-              content[:images] << inbound_link
+              content[:images] << inbound_link if inbound_link["link"].present?
             end
           end
 

--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -254,6 +254,8 @@ class Cobweb
 
           # get location to redirect to
           uri = UriHelper.join_no_fragment(uri, response['location'])
+          raise RedirectError, "Invalid redirect uri #{response['location']}" unless uri.present?
+
           logger.info "Following Redirect to #{uri}... " unless @options[:quiet]
 
           # decrement redirect limit
@@ -450,6 +452,7 @@ class Cobweb
           logger.info "redirected... " unless @options[:quiet]
 
           uri = UriHelper.join_no_fragment(uri, response['location'])
+          raise RedirectError, "Invalid redirect uri #{response['location']}" unless uri.present?
 
           redirect_limit = redirect_limit - 1
 

--- a/lib/cobweb_crawler.rb
+++ b/lib/cobweb_crawler.rb
@@ -124,14 +124,14 @@ class CobwebCrawler
             if @options[:store_inbound_links]
               Array(content_link_parser.full_link_data.select {|link| type == "link"}).each do |inbound_link|
                 target_uri = UriHelper.parse(inbound_link["link"])
-                @redis.sadd("inbound_links:#{Digest::MD5.hexdigest(target_uri.to_s)}", url.to_s)
+                @redis.sadd("inbound_links:#{Digest::MD5.hexdigest(target_uri.to_s)}", url.to_s) if target_uri.present?
               end
             end
 
             if @options[:store_inbound_anchor_text]
               Array(content_link_parser.full_link_data.select {|link| type == "link"}).each do |inbound_link|
                 target_uri = UriHelper.parse(inbound_link["link"])
-                @redis.sadd("inbound_anchors:#{Digest::MD5.hexdigest(target_uri.to_s)}", inbound_link["text"].downcase )
+                @redis.sadd("inbound_anchors:#{Digest::MD5.hexdigest(target_uri.to_s)}", inbound_link["text"].downcase ) if target_uri.present?
               end
             end
 

--- a/lib/content_link_parser.rb
+++ b/lib/content_link_parser.rb
@@ -7,7 +7,6 @@ class ContentLinkParser
 
   # Parses the content and absolutizes the urls based on url.  Options can be setup to determine the links that are extracted.
   def initialize(url, content, options = {})
-    binding.pry
     @options = {}.merge(options)
     @url = url
     @doc = Nokogiri::HTML(content)

--- a/lib/content_link_parser.rb
+++ b/lib/content_link_parser.rb
@@ -7,14 +7,14 @@ class ContentLinkParser
 
   # Parses the content and absolutizes the urls based on url.  Options can be setup to determine the links that are extracted.
   def initialize(url, content, options = {})
+    binding.pry
     @options = {}.merge(options)
     @url = url
     @doc = Nokogiri::HTML(content)
 
-    base_url = @url.to_s
     if @doc.at("base[href]")
       base_url = @doc.at("base[href]").attr("href").to_s
-      @url = base_url if base_url
+      @url = base_url if base_url.present?
     end
 
     @options[:tags] = {}

--- a/lib/content_link_parser.rb
+++ b/lib/content_link_parser.rb
@@ -76,9 +76,15 @@ class ContentLinkParser
     Array(options_to_check).each do |selector, attribute|
       @doc.css(selector).each do |node|
         if attribute == "href"
-          full_link_data << {"text" => node.text.to_s, "rel" => node["rel"], "link" => UriHelper.join_no_fragment(@url, node["href"].to_s).to_s , "alt" => node["alt"].to_s, "title" => node["title"].to_s, "type" => "link" }
-        elsif attribute == "src" && selector == "img[src]"
-          full_link_data << {"rel" => node["rel"], "link" => UriHelper.join_no_fragment(@url, node["src"].to_s).to_s, "alt" => node["alt"].to_s, "rel" => node["rel"].to_s, "title" => node["title"].to_s, "type" => "image"}
+          uri = UriHelper.join_no_fragment(@url, node["href"].to_s)
+          if uri.present?
+            full_link_data << {"text" => node.text.to_s, "rel" => node["rel"], "link" => uri.to_s , "alt" => node["alt"].to_s, "title" => node["title"].to_s, "type" => "link" }
+          elsif attribute == "src" && selector == "img[src]"
+            uri = UriHelper.join_no_fragment(@url, node["src"].to_s)
+            if uri.present?
+              full_link_data << {"rel" => node["rel"], "link" => uri.to_s, "alt" => node["alt"].to_s, "rel" => node["rel"].to_s, "title" => node["title"].to_s, "type" => "image"}
+            end
+          end
         end
       end
     end
@@ -102,7 +108,7 @@ class ContentLinkParser
     data = link_data
 
     links = data.keys.map{|key| data[key]}.flatten.uniq
-    links = links.map{|link| UriHelper.join_no_fragment(@url, link).to_s }
+    links = links.map{|link| UriHelper.join_no_fragment(@url, link)}.reject(&:nil?).map(&:to_s)
     links = links.reject{|link| link =~ /\/([^\/]+?)\/\1\// }
     links = links.reject{|link| link =~ /([^\/]+?)\/([^\/]+?)\/.*?\1\/\2/ }
     links = links.reject{|link| link =~ /\/([^\/]+\.js)/ } if @options[:exclude_js]

--- a/lib/uri_helper.rb
+++ b/lib/uri_helper.rb
@@ -11,7 +11,11 @@ class UriHelper
     begin
       URI.parse(url)
     rescue URI::InvalidURIError
-      URI.parse(URI.escape(url))
+      begin
+        URI.parse(URI.escape(url))
+      rescue URI::InvalidURIError
+        return nil # This seems to be a rotten link. Caller should check for nil 
+      end
     end
   end
 

--- a/lib/uri_helper.rb
+++ b/lib/uri_helper.rb
@@ -2,9 +2,13 @@
 class UriHelper
   # Returns an Addressable::URI with the fragment section removed
   def self.join_no_fragment(content, link)
-    new_link = Addressable::URI.join(content, link)
-    new_link.fragment=nil
-    new_link
+    begin
+      new_link = Addressable::URI.join(content, link)
+      new_link.fragment=nil
+      return new_link
+    rescue Addressable::URI::InvalidURIError
+      return nil
+    end
   end
 
   def self.parse(url)
@@ -14,7 +18,7 @@ class UriHelper
       begin
         URI.parse(URI.escape(url))
       rescue URI::InvalidURIError
-        return nil # This seems to be a rotten link. Caller should check for nil 
+        return nil # This seems to be a rotten link. Caller should check for nil
       end
     end
   end


### PR DESCRIPTION
issue #2958

This is first set of problems related to this issue. 

sites like http://www.gerr.is/ have a malformed base href
`<base href="">`

which causes the content_link_parser to use this empty string as the base to resolve relative and absolute path urls, causing them to fail.


